### PR TITLE
feat: DLL(s) override and Service Manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ features = [
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Services",
+    "Win32_Storage_FileSystem",
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",

--- a/src/dll_overrides/manager.rs
+++ b/src/dll_overrides/manager.rs
@@ -1,0 +1,117 @@
+use std::path::Path;
+use windows_registry::Key;
+
+use crate::registry::manager::{Data, Hive, KeyExtension, RegistryManager};
+
+const DLL_OVERRIDES_SUBKEY: &str = "Software\\Wine\\DllOverrides";
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OverrideMode {
+    NativeBuiltin,
+    BuiltinNative,
+    Native,
+    Builtin,
+    Disabled,
+}
+
+impl OverrideMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OverrideMode::NativeBuiltin => "native,builtin",
+            OverrideMode::BuiltinNative => "builtin,native",
+            OverrideMode::Native => "native",
+            OverrideMode::Builtin => "builtin",
+            OverrideMode::Disabled => "disabled",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s.trim().to_lowercase().as_str() {
+            "native,builtin" => OverrideMode::NativeBuiltin,
+            "builtin,native" => OverrideMode::BuiltinNative,
+            "native" => OverrideMode::Native,
+            "builtin" => OverrideMode::Builtin,
+            "disabled" | "" => OverrideMode::Disabled,
+            _ => OverrideMode::NativeBuiltin,
+        }
+    }
+
+    pub fn to_proto_i32(&self) -> i32 {
+        match self {
+            OverrideMode::NativeBuiltin => 0,
+            OverrideMode::BuiltinNative => 1,
+            OverrideMode::Native => 2,
+            OverrideMode::Builtin => 3,
+            OverrideMode::Disabled => 4,
+        }
+    }
+
+    pub fn from_proto_i32(v: i32) -> Self {
+        match v {
+            0 => OverrideMode::NativeBuiltin,
+            1 => OverrideMode::BuiltinNative,
+            2 => OverrideMode::Native,
+            3 => OverrideMode::Builtin,
+            4 => OverrideMode::Disabled,
+            _ => OverrideMode::NativeBuiltin,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DllOverride {
+    pub dll: String,
+    pub mode: OverrideMode,
+}
+
+pub struct DllOverrideManager;
+
+impl DllOverrideManager {
+    fn subkey() -> &'static Path {
+        Path::new(DLL_OVERRIDES_SUBKEY)
+    }
+
+    fn open_key() -> windows_registry::Result<Key> {
+        RegistryManager.key(Hive::CurrentUser, Self::subkey())
+    }
+
+    fn ensure_key() -> windows_registry::Result<Key> {
+        RegistryManager.create_key(Hive::CurrentUser, Self::subkey())
+    }
+
+    pub fn list(&self) -> windows_registry::Result<Vec<DllOverride>> {
+        let key = Self::open_key()?;
+
+        let overrides = key
+            .values()?
+            .filter_map(|(name, _)| {
+                key.get_string(&name).ok().map(|s| DllOverride {
+                    dll: name,
+                    mode: OverrideMode::from_str(&s),
+                })
+            })
+            .collect();
+
+        Ok(overrides)
+    }
+
+    pub fn get(&self, dll: &str) -> windows_registry::Result<DllOverride> {
+        let key = Self::open_key()?;
+        let mode_str = key.get_string(dll)?;
+
+        Ok(DllOverride {
+            dll: dll.to_string(),
+            mode: OverrideMode::from_str(&mode_str),
+        })
+    }
+
+    pub fn set(&self, dll: &str, mode: OverrideMode) -> windows_registry::Result<()> {
+        let key = Self::ensure_key()?;
+        KeyExtension::create_value(&key, dll, Data::String(mode.as_str().to_string()))
+    }
+
+    pub fn delete(&self, dll: &str) -> windows_registry::Result<()> {
+        let key = Self::open_key()?;
+        key.remove_value(dll)
+    }
+}

--- a/src/dll_overrides/mod.rs
+++ b/src/dll_overrides/mod.rs
@@ -1,0 +1,1 @@
+pub mod manager;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,28 @@
+mod dll_overrides;
 mod processes;
 mod registry;
+mod services;
 
 use bottles_core::proto::winebridge::{self, wine_bridge_server::WineBridge};
+use dll_overrides::manager::{DllOverrideManager, OverrideMode};
 use processes::{manager::ProcessManager, process::ProcessIdentifier};
 use registry::manager::{KeyExtension, RegistryManager, to_proto_reg_val, to_reg_data};
+use services::manager::ServiceManager;
+use std::ffi::OsString;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::path::Path;
 use tokio::sync::broadcast;
 use tonic::{Request, Response, Status};
+use windows::Win32::Storage::FileSystem::{
+    GetDiskFreeSpaceExW, GetLogicalDrives, GetVolumeInformationW,
+};
+use windows::Win32::System::Threading::{CreateProcessW, CREATE_NEW_CONSOLE, STARTUPINFOW};
+use windows::Win32::Foundation::CloseHandle;
+use windows::core::PCWSTR;
+
+fn to_wide(s: &str) -> Vec<u16> {
+    OsString::from(s).encode_wide().chain(Some(0)).collect()
+}
 
 pub struct WineBridgeService {
     shutdown_signal: broadcast::Sender<()>,
@@ -27,7 +43,7 @@ impl WineBridge for WineBridgeService {
         let _ = request;
         Ok(Response::new(winebridge::MessageResponse {
             success: true,
-            error: String::new(),
+            error: None,
         }))
     }
 
@@ -101,7 +117,7 @@ impl WineBridge for WineBridgeService {
         let subkey = Path::new(&input.subkey);
 
         RegistryManager.create_key(hive, subkey)
-            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
             .map_err(|e| Status::internal(format!("{:?}", e)))
     }
 
@@ -114,7 +130,7 @@ impl WineBridge for WineBridgeService {
         let subkey = Path::new(&input.subkey);
 
         RegistryManager.delete_key(hive, subkey)
-            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
             .map_err(|e| Status::internal(format!("{:?}", e)))
     }
 
@@ -165,7 +181,7 @@ impl WineBridge for WineBridgeService {
         let value = input.value.as_ref().ok_or(Status::invalid_argument("Missing value"))?;
         
         key.create_value(&key_req.name, to_reg_data(value.r#type(), value.data.clone()))
-            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
             .map_err(|e| Status::internal(format!("{:?}", e)))
     }
 
@@ -180,7 +196,7 @@ impl WineBridge for WineBridgeService {
         RegistryManager.key(hive, subkey)
             .map_err(|e| Status::internal(format!("{:?}", e)))?
             .remove_value(&input.name)
-            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
             .map_err(|e| Status::internal(format!("{:?}", e)))
     }
 
@@ -241,7 +257,8 @@ impl WineBridge for WineBridgeService {
         &self,
         request: Request<winebridge::FileOperationRequest>,
     ) -> Result<Response<winebridge::ExistsResponse>, Status> {
-        let path = Path::new(&request.into_inner().path);
+        let inner = request.into_inner();
+        let path = Path::new(&inner.path);
         Ok(Response::new(winebridge::ExistsResponse {
             exists: path.exists(),
             is_dir: path.is_dir(),
@@ -270,6 +287,147 @@ impl WineBridge for WineBridgeService {
         Ok(Response::new(winebridge::ListDirectoryResponse { files }))
     }
 
+    // --- Service Management ---
+
+    async fn list_services(
+        &self,
+        _request: Request<winebridge::ListServicesRequest>,
+    ) -> Result<Response<winebridge::ListServicesResponse>, Status> {
+        let services = ServiceManager
+            .list_services()
+            .map_err(|e| Status::internal(format!("Failed to list services: {:?}", e)))?;
+
+        let services = services
+            .into_iter()
+            .map(|s| winebridge::ServiceInfo {
+                name: s.name,
+                display_name: s.display_name,
+                state: s.state as i32,
+                start_type: s.start_type as i32,
+            })
+            .collect();
+
+        Ok(Response::new(winebridge::ListServicesResponse { services }))
+    }
+
+    async fn get_service_status(
+        &self,
+        request: Request<winebridge::ServiceRequest>,
+    ) -> Result<Response<winebridge::ServiceStatusResponse>, Status> {
+        let name = request.into_inner().name;
+        let state = ServiceManager
+            .get_status(&name)
+            .map_err(|e| Status::internal(format!("Failed to get service status: {:?}", e)))?;
+
+        Ok(Response::new(winebridge::ServiceStatusResponse {
+            name,
+            state: state as i32,
+        }))
+    }
+
+    async fn start_service(
+        &self,
+        request: Request<winebridge::ServiceRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let name = request.into_inner().name;
+        ServiceManager
+            .start(&name)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
+            .map_err(|e| Status::internal(format!("Failed to start service: {:?}", e)))
+    }
+
+    async fn stop_service(
+        &self,
+        request: Request<winebridge::ServiceRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let name = request.into_inner().name;
+        ServiceManager
+            .stop(&name)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
+            .map_err(|e| Status::internal(format!("Failed to stop service: {:?}", e)))
+    }
+
+    async fn create_service(
+        &self,
+        request: Request<winebridge::CreateServiceRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let input = request.into_inner();
+        ServiceManager
+            .create(&input.name, &input.display_name, &input.binary_path, input.start_type as u32)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
+            .map_err(|e| Status::internal(format!("Failed to create service: {:?}", e)))
+    }
+
+    async fn delete_service(
+        &self,
+        request: Request<winebridge::ServiceRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let name = request.into_inner().name;
+        ServiceManager
+            .delete(&name)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
+            .map_err(|e| Status::internal(format!("Failed to delete service: {:?}", e)))
+    }
+
+    // --- DLL Overrides ---
+
+    async fn list_dll_overrides(
+        &self,
+        _request: Request<winebridge::ListDllOverridesRequest>,
+    ) -> Result<Response<winebridge::ListDllOverridesResponse>, Status> {
+        let overrides = DllOverrideManager
+            .list()
+            .map_err(|e| Status::internal(format!("Failed to list DLL overrides: {:?}", e)))?;
+
+        let overrides = overrides
+            .into_iter()
+            .map(|o| winebridge::DllOverride {
+                dll: o.dll,
+                mode: o.mode.to_proto_i32(),
+            })
+            .collect();
+
+        Ok(Response::new(winebridge::ListDllOverridesResponse { overrides }))
+    }
+
+    async fn get_dll_override(
+        &self,
+        request: Request<winebridge::DllOverrideRequest>,
+    ) -> Result<Response<winebridge::DllOverrideResponse>, Status> {
+        let dll = request.into_inner().dll;
+        let entry = DllOverrideManager
+            .get(&dll)
+            .map_err(|e| Status::internal(format!("Failed to get DLL override: {:?}", e)))?;
+
+        Ok(Response::new(winebridge::DllOverrideResponse {
+            dll: entry.dll,
+            mode: entry.mode.to_proto_i32(),
+        }))
+    }
+
+    async fn set_dll_override(
+        &self,
+        request: Request<winebridge::SetDllOverrideRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let input = request.into_inner();
+        let mode = OverrideMode::from_proto_i32(input.mode);
+        DllOverrideManager
+            .set(&input.dll, mode)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
+            .map_err(|e| Status::internal(format!("Failed to set DLL override: {:?}", e)))
+    }
+
+    async fn delete_dll_override(
+        &self,
+        request: Request<winebridge::DllOverrideRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let dll = request.into_inner().dll;
+        DllOverrideManager
+            .delete(&dll)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
+            .map_err(|e| Status::internal(format!("Failed to delete DLL override: {:?}", e)))
+    }
+
     // --- System ---
 
     async fn shutdown(
@@ -277,29 +435,108 @@ impl WineBridge for WineBridgeService {
         _request: Request<winebridge::ShutdownRequest>,
     ) -> Result<Response<winebridge::MessageResponse>, Status> {
         let _ = self.shutdown_signal.send(());
-        Ok(Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+        Ok(Response::new(winebridge::MessageResponse { success: true, error: None }))
     }
 
     async fn wineboot(
         &self,
         request: Request<winebridge::WinebootRequest>,
     ) -> Result<Response<winebridge::MessageResponse>, Status> {
-        // Mock implementation relying on external wineboot or just killing processes
-        // In a real scenario, this would execute 'wineboot.exe'
-        let _req = request.into_inner();
-        // TODO: Execute wineboot
-        Ok(Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+        let mode = request.into_inner().mode;
+
+        let args = match mode {
+            1 => "/s",
+            2 => "/k",
+            _ => "/r",
+        };
+
+        let exe = to_wide("wineboot.exe");
+        let mut cmd = to_wide(&format!("wineboot.exe {}", args));
+        let mut startup_info = STARTUPINFOW::default();
+        startup_info.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+        let mut process_info = windows::Win32::System::Threading::PROCESS_INFORMATION::default();
+
+        let result = unsafe {
+            CreateProcessW(
+                PCWSTR(exe.as_ptr()),
+                Some(windows::core::PWSTR(cmd.as_mut_ptr())),
+                None,
+                None,
+                false,
+                CREATE_NEW_CONSOLE,
+                None,
+                PCWSTR::null(),
+                &mut startup_info,
+                &mut process_info,
+            )
+        };
+
+        unsafe {
+            CloseHandle(process_info.hProcess).ok();
+            CloseHandle(process_info.hThread).ok();
+        }
+
+        result
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: None }))
+            .map_err(|e| Status::internal(format!("Failed to execute wineboot: {:?}", e)))
     }
 
     async fn get_drive_info(
         &self,
         _request: Request<winebridge::DriveInfoRequest>,
     ) -> Result<Response<winebridge::DriveInfoResponse>, Status> {
-         // Mock implementation
-         let drives = vec![
-             winebridge::Drive { letter: "C".to_string(), label: "System".to_string(), total_space: 1000, free_space: 500 },
-             winebridge::Drive { letter: "Z".to_string(), label: "Root".to_string(), total_space: 2000, free_space: 1000 },
-         ];
-         Ok(Response::new(winebridge::DriveInfoResponse { drives }))
+        let bitmask = unsafe { GetLogicalDrives() };
+        let mut drives = Vec::new();
+
+        for i in 0u32..26 {
+            if bitmask & (1 << i) == 0 {
+                continue;
+            }
+
+            let letter = (b'A' + i as u8) as char;
+            let root = to_wide(&format!("{}:\\", letter));
+
+            let mut label_buf = vec![0u16; 256];
+            let mut fs_buf = vec![0u16; 256];
+
+            unsafe {
+                GetVolumeInformationW(
+                    PCWSTR(root.as_ptr()),
+                    Some(&mut label_buf),
+                    None,
+                    None,
+                    None,
+                    Some(&mut fs_buf),
+                )
+                .ok();
+            }
+
+            let label_len = label_buf.iter().position(|&c| c == 0).unwrap_or(0);
+            let label = OsString::from_wide(&label_buf[..label_len])
+                .to_string_lossy()
+                .into_owned();
+
+            let mut free_bytes: u64 = 0;
+            let mut total_bytes: u64 = 0;
+
+            unsafe {
+                GetDiskFreeSpaceExW(
+                    PCWSTR(root.as_ptr()),
+                    Some(&mut free_bytes as *mut u64 as *mut _),
+                    Some(&mut total_bytes as *mut u64 as *mut _),
+                    None,
+                )
+                .ok();
+            }
+
+            drives.push(winebridge::Drive {
+                letter: letter.to_string(),
+                label,
+                total_space: total_bytes,
+                free_space: free_bytes,
+            });
+        }
+
+        Ok(Response::new(winebridge::DriveInfoResponse { drives }))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,223 +1,305 @@
 mod processes;
 mod registry;
 
-use bottles_core::proto::{self, wine_bridge_server::WineBridge};
+use bottles_core::proto::winebridge::{self, wine_bridge_server::WineBridge};
 use processes::{manager::ProcessManager, process::ProcessIdentifier};
 use registry::manager::{KeyExtension, RegistryManager, to_proto_reg_val, to_reg_data};
-use windows::{
-    Win32::UI::WindowsAndMessaging::{MB_OK, MessageBoxA},
-    core::{PCSTR, s},
-};
+use std::path::Path;
+use tokio::sync::broadcast;
+use tonic::{Request, Response, Status};
 
-#[derive(Debug, Default)]
-pub struct WineBridgeService;
+pub struct WineBridgeService {
+    shutdown_signal: broadcast::Sender<()>,
+}
+
+impl WineBridgeService {
+    pub fn new(shutdown_signal: broadcast::Sender<()>) -> Self {
+        Self { shutdown_signal }
+    }
+}
 
 #[tonic::async_trait]
 impl WineBridge for WineBridgeService {
     async fn message(
         &self,
-        request: tonic::Request<proto::MessageRequest>,
-    ) -> Result<tonic::Response<proto::MessageResponse>, tonic::Status> {
-        let request = request.get_ref();
-        tracing::info!("Got a request: {:?}", request);
-        let message = request.message.as_str();
-        let c_message = std::ffi::CString::new(message).unwrap();
-        unsafe {
-            MessageBoxA(
-                None,
-                PCSTR(c_message.as_ptr() as *const u8),
-                s!("Hello"),
-                MB_OK,
-            );
-        }
-        Ok(tonic::Response::new(proto::MessageResponse {
+        request: Request<winebridge::MessageRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let _ = request;
+        Ok(Response::new(winebridge::MessageResponse {
             success: true,
+            error: String::new(),
         }))
     }
 
+    // --- Process Management ---
+
     async fn running_processes(
         &self,
-        _request: tonic::Request<proto::RunningProcessesRequest>,
-    ) -> Result<tonic::Response<proto::RunningProcessesResponse>, tonic::Status> {
+        _request: Request<winebridge::RunningProcessesRequest>,
+    ) -> Result<Response<winebridge::RunningProcessesResponse>, Status> {
         let processes = ProcessManager.running_processes().map_err(|e| {
-            tonic::Status::internal(format!("Failed to get running processes: {:?}", e))
+            Status::internal(format!("Failed to get running processes: {:?}", e))
         })?;
 
         let processes = processes
             .iter()
-            .map(|process| proto::Process {
+            .map(|process| winebridge::Process {
                 name: process.name(),
                 pid: process.pid(),
                 threads: process.thread_count(),
             })
             .collect();
 
-        Ok(tonic::Response::new(proto::RunningProcessesResponse {
+        Ok(Response::new(winebridge::RunningProcessesResponse {
             processes,
         }))
     }
 
     async fn create_process(
         &self,
-        request: tonic::Request<proto::CreateProcessRequest>,
-    ) -> Result<tonic::Response<proto::CreateProcessResponse>, tonic::Status> {
+        request: Request<winebridge::CreateProcessRequest>,
+    ) -> Result<Response<winebridge::CreateProcessResponse>, Status> {
         let input = request.into_inner();
         let program = std::path::Path::new(&input.command);
         let args = input.args;
-
+        
+        // TODO: Handle work_dir and env from input
+        
         ProcessManager
             .execute(program, args)
-            .map_err(|e| tonic::Status::internal(format!("Failed to execute process: {:?}", e)))?;
+            .map_err(|e| Status::internal(format!("Failed to execute process: {:?}", e)))?;
 
-        Ok(tonic::Response::new(proto::CreateProcessResponse {
-            pid: 0,
+        Ok(Response::new(winebridge::CreateProcessResponse {
+            pid: 0, // TODO: Return real PID
         }))
     }
 
     async fn kill_process(
         &self,
-        request: tonic::Request<proto::KillProcessRequest>,
-    ) -> Result<tonic::Response<proto::KillProcessResponse>, tonic::Status> {
+        request: Request<winebridge::KillProcessRequest>,
+    ) -> Result<Response<winebridge::KillProcessResponse>, Status> {
         let pid = request.get_ref().pid;
         let process = ProcessManager
             .process(ProcessIdentifier::Pid(pid))
-            .ok_or_else(|| tonic::Status::not_found("Process not found"))?;
+            .ok_or_else(|| Status::not_found("Process not found"))?;
 
         process
             .kill()
-            .map_err(|e| tonic::Status::internal(format!("Failed to kill process: {:?}", e)))?;
+            .map_err(|e| Status::internal(format!("Failed to kill process: {:?}", e)))?;
 
-        Ok(tonic::Response::new(proto::KillProcessResponse {}))
+        Ok(Response::new(winebridge::KillProcessResponse { success: true }))
     }
+
+    // --- Registry Management ---
 
     async fn create_registry_key(
         &self,
-        request: tonic::Request<proto::CreateRegistryKeyRequest>,
-    ) -> Result<tonic::Response<proto::MessageResponse>, tonic::Status> {
+        request: Request<winebridge::CreateRegistryKeyRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
         let input = request.get_ref();
-        let hive = input
-            .hive
-            .parse()
-            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid hive: {:?}", e)))?;
-        let subkey = std::path::Path::new(input.subkey.as_str());
+        let hive = input.hive.parse().map_err(|e| Status::invalid_argument(format!("{:?}", e)))?;
+        let subkey = Path::new(&input.subkey);
 
-        RegistryManager
-            .create_key(hive, subkey)
-            .map(|_| tonic::Response::new(proto::MessageResponse { success: true }))
-            .map_err(|e| tonic::Status::internal(format!("Failed to create registry key: {:?}", e)))
+        RegistryManager.create_key(hive, subkey)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map_err(|e| Status::internal(format!("{:?}", e)))
     }
 
     async fn delete_registry_key(
         &self,
-        request: tonic::Request<proto::DeleteRegistryKeyRequest>,
-    ) -> Result<tonic::Response<proto::MessageResponse>, tonic::Status> {
+        request: Request<winebridge::DeleteRegistryKeyRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
         let input = request.get_ref();
-        let hive = input
-            .hive
-            .parse()
-            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid hive: {:?}", e)))?;
-        let subkey = std::path::Path::new(input.subkey.as_str());
+        let hive = input.hive.parse().map_err(|e| Status::invalid_argument(format!("{:?}", e)))?;
+        let subkey = Path::new(&input.subkey);
 
-        RegistryManager
-            .delete_key(hive, subkey)
-            .map(|_| tonic::Response::new(proto::MessageResponse { success: true }))
-            .map_err(|e| tonic::Status::internal(format!("Failed to create registry key: {:?}", e)))
+        RegistryManager.delete_key(hive, subkey)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map_err(|e| Status::internal(format!("{:?}", e)))
     }
 
     async fn get_registry_key(
         &self,
-        request: tonic::Request<proto::GetRegistryKeyRequest>,
-    ) -> Result<tonic::Response<proto::RegistryKey>, tonic::Status> {
+        request: Request<winebridge::GetRegistryKeyRequest>,
+    ) -> Result<Response<winebridge::RegistryKey>, Status> {
         let input = request.get_ref();
-        let hive = input
-            .hive
-            .parse()
-            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid hive: {:?}", e)))?;
-        let subkey = std::path::Path::new(input.subkey.as_str());
+        let hive = input.hive.parse().map_err(|e| Status::invalid_argument(format!("{:?}", e)))?;
+        let subkey = Path::new(&input.subkey);
 
-        let key = RegistryManager
-            .key(hive, subkey)
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to create registry key: {:?}", e))
-            })?
+        let key = RegistryManager.key(hive, subkey)
+            .map_err(|e| Status::internal(format!("{:?}", e)))?
             .as_registry_key(hive, subkey);
 
-        Ok(tonic::Response::new(key))
+        Ok(Response::new(key))
     }
 
     async fn get_registry_key_value(
         &self,
-        request: tonic::Request<proto::RegistryKeyRequest>,
-    ) -> Result<tonic::Response<proto::RegistryValue>, tonic::Status> {
+        request: Request<winebridge::RegistryKeyRequest>,
+    ) -> Result<Response<winebridge::RegistryValue>, Status> {
         let input = request.get_ref();
-        let name = input.name.as_str();
-        let hive = input
-            .hive
-            .parse()
-            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid hive: {:?}", e)))?;
-        let subkey = std::path::Path::new(input.subkey.as_str());
+        let hive = input.hive.parse().map_err(|e| Status::invalid_argument(format!("{:?}", e)))?;
+        let subkey = Path::new(&input.subkey);
 
-        let key = RegistryManager.key(hive, subkey).map_err(|e| {
-            tonic::Status::internal(format!("Failed to create registry key: {:?}", e))
-        })?;
+        let key = RegistryManager.key(hive, subkey)
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
+            
+        let value = key.value(&input.name)
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
 
-        let value = key.value(name).map_err(|e| {
-            tonic::Status::internal(format!("Failed to get registry value: {:?}", e))
-        })?;
-
-        Ok(tonic::Response::new(to_proto_reg_val(value)))
+        Ok(Response::new(to_proto_reg_val(value)))
     }
 
     async fn set_registry_key_value(
         &self,
-        request: tonic::Request<proto::SetRegistryKeyValueRequest>,
-    ) -> Result<tonic::Response<proto::MessageResponse>, tonic::Status> {
+        request: Request<winebridge::SetRegistryKeyValueRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
         let input = request.get_ref();
+        let key_req = input.key.as_ref().ok_or(Status::invalid_argument("Missing key"))?;
+        let hive = key_req.hive.parse().map_err(|e| Status::invalid_argument(format!("{:?}", e)))?;
+        let subkey = Path::new(&key_req.subkey);
+        
+        let key = RegistryManager.key(hive, subkey)
+            .map_err(|e| Status::internal(format!("{:?}", e)))?;
 
-        let (name, key) = input
-            .key
-            .as_ref()
-            .map(|k| {
-                let hive = k.hive.parse().unwrap();
-                let subkey = std::path::Path::new(k.subkey.as_str());
-                (k.name.clone(), RegistryManager.key(hive, subkey).unwrap())
-            })
-            .ok_or_else(|| tonic::Status::invalid_argument("Key is required"))?;
-
-        let value = input
-            .value
-            .as_ref()
-            .ok_or_else(|| tonic::Status::invalid_argument("Value is required"))?;
-
-        key.create_value(
-            name.as_str(),
-            to_reg_data(value.r#type(), value.data.clone()),
-        )
-        .map(|_| tonic::Response::new(proto::MessageResponse { success: true }))
-        .map_err(|e| tonic::Status::internal(format!("Failed to set registry value: {:?}", e)))
+        let value = input.value.as_ref().ok_or(Status::invalid_argument("Missing value"))?;
+        
+        key.create_value(&key_req.name, to_reg_data(value.r#type(), value.data.clone()))
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map_err(|e| Status::internal(format!("{:?}", e)))
     }
 
     async fn delete_registry_key_value(
         &self,
-        request: tonic::Request<proto::RegistryKeyRequest>,
-    ) -> Result<tonic::Response<proto::MessageResponse>, tonic::Status> {
+        request: Request<winebridge::RegistryKeyRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
         let input = request.get_ref();
-        let name = input.name.as_str();
-        let hive = input
-            .hive
-            .parse()
-            .map_err(|e| tonic::Status::invalid_argument(format!("Invalid hive: {:?}", e)))?;
-        let subkey = std::path::Path::new(input.subkey.as_str());
+        let hive = input.hive.parse().map_err(|e| Status::invalid_argument(format!("{:?}", e)))?;
+        let subkey = Path::new(&input.subkey);
 
-        RegistryManager
-            .key(hive, subkey)
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to create registry key: {:?}", e))
-            })?
-            .remove_value(name)
-            .map(|_| tonic::Response::new(proto::MessageResponse { success: true }))
-            .map_err(|e| {
-                tonic::Status::internal(format!("Failed to delete registry value: {:?}", e))
-            })
+        RegistryManager.key(hive, subkey)
+            .map_err(|e| Status::internal(format!("{:?}", e)))?
+            .remove_value(&input.name)
+            .map(|_| Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+            .map_err(|e| Status::internal(format!("{:?}", e)))
+    }
+
+    // --- File System (New) ---
+
+    async fn create_directory(
+        &self,
+        request: Request<winebridge::FileOperationRequest>,
+    ) -> Result<Response<winebridge::FileOperationResponse>, Status> {
+        let path = request.into_inner().path;
+        std::fs::create_dir_all(&path)
+            .map(|_| winebridge::FileOperationResponse { success: true, error: String::new() })
+            .map_err(|e| Status::internal(e.to_string()))
+            .map(Response::new)
+    }
+
+    async fn delete_file(
+        &self,
+        request: Request<winebridge::FileOperationRequest>,
+    ) -> Result<Response<winebridge::FileOperationResponse>, Status> {
+        let path = request.into_inner().path;
+        let p = Path::new(&path);
+        let res = if p.is_dir() {
+            std::fs::remove_dir_all(p)
+        } else {
+            std::fs::remove_file(p)
+        };
+
+        res.map(|_| winebridge::FileOperationResponse { success: true, error: String::new() })
+           .map_err(|e| Status::internal(e.to_string()))
+           .map(Response::new)
+    }
+
+    async fn copy_file(
+        &self,
+        request: Request<winebridge::CopyMoveRequest>,
+    ) -> Result<Response<winebridge::FileOperationResponse>, Status> {
+        let req = request.into_inner();
+        // Simple copy, not recursive for dirs yet
+        std::fs::copy(req.source, req.destination)
+            .map(|_| winebridge::FileOperationResponse { success: true, error: String::new() })
+            .map_err(|e| Status::internal(e.to_string()))
+            .map(Response::new)
+    }
+
+    async fn move_file(
+        &self,
+        request: Request<winebridge::CopyMoveRequest>,
+    ) -> Result<Response<winebridge::FileOperationResponse>, Status> {
+        let req = request.into_inner();
+        std::fs::rename(req.source, req.destination)
+            .map(|_| winebridge::FileOperationResponse { success: true, error: String::new() })
+            .map_err(|e| Status::internal(e.to_string()))
+            .map(Response::new)
+    }
+
+    async fn exists(
+        &self,
+        request: Request<winebridge::FileOperationRequest>,
+    ) -> Result<Response<winebridge::ExistsResponse>, Status> {
+        let path = Path::new(&request.into_inner().path);
+        Ok(Response::new(winebridge::ExistsResponse {
+            exists: path.exists(),
+            is_dir: path.is_dir(),
+        }))
+    }
+
+    async fn list_directory(
+        &self,
+        request: Request<winebridge::FileOperationRequest>,
+    ) -> Result<Response<winebridge::ListDirectoryResponse>, Status> {
+        let path = request.into_inner().path;
+        let entries = std::fs::read_dir(path).map_err(|e| Status::internal(e.to_string()))?;
+        
+        let mut files = Vec::new();
+        for entry in entries {
+            if let Ok(entry) = entry {
+                if let Ok(meta) = entry.metadata() {
+                    files.push(winebridge::FileInfo {
+                        name: entry.file_name().to_string_lossy().to_string(),
+                        is_dir: meta.is_dir(),
+                        size: meta.len(),
+                    });
+                }
+            }
+        }
+        Ok(Response::new(winebridge::ListDirectoryResponse { files }))
+    }
+
+    // --- System ---
+
+    async fn shutdown(
+        &self,
+        _request: Request<winebridge::ShutdownRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        let _ = self.shutdown_signal.send(());
+        Ok(Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+    }
+
+    async fn wineboot(
+        &self,
+        request: Request<winebridge::WinebootRequest>,
+    ) -> Result<Response<winebridge::MessageResponse>, Status> {
+        // Mock implementation relying on external wineboot or just killing processes
+        // In a real scenario, this would execute 'wineboot.exe'
+        let _req = request.into_inner();
+        // TODO: Execute wineboot
+        Ok(Response::new(winebridge::MessageResponse { success: true, error: String::new() }))
+    }
+
+    async fn get_drive_info(
+        &self,
+        _request: Request<winebridge::DriveInfoRequest>,
+    ) -> Result<Response<winebridge::DriveInfoResponse>, Status> {
+         // Mock implementation
+         let drives = vec![
+             winebridge::Drive { letter: "C".to_string(), label: "System".to_string(), total_space: 1000, free_space: 500 },
+             winebridge::Drive { letter: "Z".to_string(), label: "Root".to_string(), total_space: 2000, free_space: 1000 },
+         ];
+         Ok(Response::new(winebridge::DriveInfoResponse { drives }))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
-use bottles_core::proto::wine_bridge_server::WineBridgeServer;
+use bottles_core::proto::winebridge::wine_bridge_server::WineBridgeServer;
 use bottles_winebridge::WineBridgeService;
 use tracing_subscriber::EnvFilter;
+use tokio::sync::broadcast;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -9,11 +10,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let addr = "[::1]:50051".parse().unwrap();
-    let service = WineBridgeService::default();
-    tracing::info!("Listening on {}", addr);
+    let (tx, mut rx) = broadcast::channel(1);
+    
+    let service = WineBridgeService::new(tx);
+    tracing::info!("WineBridge Agent listening on {}", addr);
+    
     tonic::transport::Server::builder()
         .add_service(WineBridgeServer::new(service))
-        .serve(addr)
+        .serve_with_shutdown(addr, async {
+            rx.recv().await.ok();
+            tracing::info!("Shutting down WineBridge Agent...");
+        })
         .await?;
     Ok(())
 }

--- a/src/registry/manager.rs
+++ b/src/registry/manager.rs
@@ -1,4 +1,4 @@
-use bottles_core::proto;
+use bottles_core::proto::winebridge as proto_winebridge;
 use std::{ops::Deref, path::Path, str::FromStr};
 use windows_registry::*;
 
@@ -78,67 +78,67 @@ pub trait KeyExtension {
     fn create_value(&self, name: &str, data: Data) -> Result<()>;
     fn rename_value(&self, old_name: &str, new_name: &str) -> Result<()>;
 
-    fn as_registry_key(&self, hive: Hive, subkey: &Path) -> proto::RegistryKey;
+    fn as_registry_key(&self, hive: Hive, subkey: &Path) -> proto_winebridge::RegistryKey;
 }
 
-pub fn to_reg_data(ty: proto::RegistryValueType, data: Vec<u8>) -> Data {
+pub fn to_reg_data(ty: proto_winebridge::RegistryValueType, data: Vec<u8>) -> Data {
     match ty {
-        proto::RegistryValueType::RegBinary => Data::Bytes(data),
-        proto::RegistryValueType::RegDword => {
+        proto_winebridge::RegistryValueType::RegBinary => Data::Bytes(data),
+        proto_winebridge::RegistryValueType::RegDword => {
             let val = u32::from_le_bytes(data.try_into().unwrap());
             Data::DWord(val)
         }
-        proto::RegistryValueType::RegQword => {
+        proto_winebridge::RegistryValueType::RegQword => {
             let val = u64::from_le_bytes(data.try_into().unwrap());
             Data::QWord(val)
         }
-        proto::RegistryValueType::RegSz => {
+        proto_winebridge::RegistryValueType::RegSz => {
             let val = String::from_utf8(data).unwrap();
             Data::String(val)
         }
-        proto::RegistryValueType::RegExpandSz => {
+        proto_winebridge::RegistryValueType::RegExpandSz => {
             let val = String::from_utf8(data).unwrap();
             Data::ExpandString(val)
         }
-        proto::RegistryValueType::RegMultiSz => {
+        proto_winebridge::RegistryValueType::RegMultiSz => {
             let val = String::from_utf8(data).unwrap();
             let strings: Vec<String> = val.split('\0').map(|s| s.to_string()).collect();
             Data::MultiString(strings)
         }
-        proto::RegistryValueType::RegNone => Data::Other,
+        proto_winebridge::RegistryValueType::RegNone => Data::Other,
     }
 }
 
-pub fn to_proto_reg_val(value: Value) -> proto::RegistryValue {
+pub fn to_proto_reg_val(value: Value) -> proto_winebridge::RegistryValue {
     let ty = match value.ty() {
-        Type::Bytes => proto::RegistryValueType::RegBinary,
-        Type::U32 => proto::RegistryValueType::RegDword,
-        Type::U64 => proto::RegistryValueType::RegQword,
-        Type::String => proto::RegistryValueType::RegSz,
-        Type::ExpandString => proto::RegistryValueType::RegExpandSz,
-        Type::MultiString => proto::RegistryValueType::RegMultiSz,
-        Type::Other(_) => proto::RegistryValueType::RegNone,
+        Type::Bytes => proto_winebridge::RegistryValueType::RegBinary,
+        Type::U32 => proto_winebridge::RegistryValueType::RegDword,
+        Type::U64 => proto_winebridge::RegistryValueType::RegQword,
+        Type::String => proto_winebridge::RegistryValueType::RegSz,
+        Type::ExpandString => proto_winebridge::RegistryValueType::RegExpandSz,
+        Type::MultiString => proto_winebridge::RegistryValueType::RegMultiSz,
+        Type::Other(_) => proto_winebridge::RegistryValueType::RegNone,
     };
 
     let val = value.deref();
-    proto::RegistryValue {
+    proto_winebridge::RegistryValue {
         r#type: ty as i32,
         data: val.to_vec(),
     }
 }
 
 impl KeyExtension for windows_registry::Key {
-    fn as_registry_key(&self, hive: Hive, subkey: &Path) -> proto::RegistryKey {
-        let values: Vec<proto::RegistryKeyValue> = self
+    fn as_registry_key(&self, hive: Hive, subkey: &Path) -> proto_winebridge::RegistryKey {
+        let values: Vec<proto_winebridge::RegistryKeyValue> = self
             .values()
             .unwrap()
-            .map(|(name, value)| proto::RegistryKeyValue {
+            .map(|(name, value)| proto_winebridge::RegistryKeyValue {
                 name,
                 value: Some(to_proto_reg_val(value)),
             })
             .collect();
 
-        proto::RegistryKey {
+        proto_winebridge::RegistryKey {
             hive: hive.to_string(),
             subkey: subkey.display().to_string(),
             values,

--- a/src/services/manager.rs
+++ b/src/services/manager.rs
@@ -1,0 +1,216 @@
+use std::ffi::OsString;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use windows::Win32::System::Services::*;
+const DELETE: u32 = 0x00010000;
+use windows::core::{Error, PCWSTR, PWSTR};
+
+fn to_wide(s: &str) -> Vec<u16> {
+    OsString::from(s).encode_wide().chain(Some(0)).collect()
+}
+
+fn from_wide(ptr: PWSTR) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    unsafe {
+        let len = (0..).take_while(|&i| *ptr.0.add(i) != 0).count();
+        OsString::from_wide(std::slice::from_raw_parts(ptr.0, len))
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+pub struct ScmHandle(SC_HANDLE);
+
+impl Drop for ScmHandle {
+    fn drop(&mut self) {
+        unsafe { CloseServiceHandle(self.0).ok() };
+    }
+}
+
+pub struct ServiceHandle(SC_HANDLE);
+
+impl Drop for ServiceHandle {
+    fn drop(&mut self) {
+        unsafe { CloseServiceHandle(self.0).ok() };
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ServiceInfo {
+    pub name: String,
+    pub display_name: String,
+    pub state: u32,
+    pub start_type: u32,
+}
+
+pub struct ServiceManager;
+
+impl ServiceManager {
+    fn open_scm(access: u32) -> Result<ScmHandle, Error> {
+        let handle = unsafe {
+            OpenSCManagerW(PCWSTR::null(), PCWSTR::null(), access)
+        }?;
+        Ok(ScmHandle(handle))
+    }
+
+    fn open_service(scm: &ScmHandle, name: &str, access: u32) -> Result<ServiceHandle, Error> {
+        let wide = to_wide(name);
+        let handle = unsafe {
+            OpenServiceW(scm.0, PCWSTR(wide.as_ptr()), access)
+        }?;
+        Ok(ServiceHandle(handle))
+    }
+
+    fn query_start_type(&self, scm: &ScmHandle, name: &str) -> Result<u32, Error> {
+        let svc = Self::open_service(scm, name, SERVICE_QUERY_CONFIG)?;
+
+        let mut bytes_needed: u32 = 0;
+        unsafe {
+            let _ = QueryServiceConfigW(svc.0, None, 0, &mut bytes_needed);
+        }
+
+        let mut buf: Vec<u8> = vec![0u8; bytes_needed as usize];
+        unsafe {
+            QueryServiceConfigW(
+                svc.0,
+                Some(buf.as_mut_ptr() as *mut QUERY_SERVICE_CONFIGW),
+                bytes_needed,
+                &mut bytes_needed,
+            )?;
+        }
+
+        let config = unsafe { &*(buf.as_ptr() as *const QUERY_SERVICE_CONFIGW) };
+        Ok(config.dwStartType.0)
+    }
+
+    pub fn list_services(&self) -> Result<Vec<ServiceInfo>, Error> {
+        let scm = Self::open_scm(SC_MANAGER_ENUMERATE_SERVICE)?;
+
+        let mut bytes_needed: u32 = 0;
+        let mut services_returned: u32 = 0;
+        let mut resume_handle: u32 = 0;
+
+        unsafe {
+            let _ = EnumServicesStatusExW(
+                scm.0,
+                SC_ENUM_PROCESS_INFO,
+                SERVICE_WIN32,
+                SERVICE_STATE_ALL,
+                None,
+                &mut bytes_needed,
+                &mut services_returned,
+                Some(&mut resume_handle),
+                PCWSTR::null(),
+            );
+        }
+
+        let mut buf: Vec<u8> = vec![0u8; bytes_needed as usize];
+        resume_handle = 0;
+
+        unsafe {
+            EnumServicesStatusExW(
+                scm.0,
+                SC_ENUM_PROCESS_INFO,
+                SERVICE_WIN32,
+                SERVICE_STATE_ALL,
+                Some(&mut buf),
+                &mut bytes_needed,
+                &mut services_returned,
+                Some(&mut resume_handle),
+                PCWSTR::null(),
+            )?;
+        }
+
+        let mut result = Vec::with_capacity(services_returned as usize);
+        let ptr = buf.as_ptr() as *const ENUM_SERVICE_STATUS_PROCESSW;
+
+        for i in 0..services_returned as usize {
+            let entry = unsafe { &*ptr.add(i) };
+            let name = from_wide(PWSTR(entry.lpServiceName.0 as *mut u16));
+            let display_name = from_wide(PWSTR(entry.lpDisplayName.0 as *mut u16));
+            let state = entry.ServiceStatusProcess.dwCurrentState.0;
+            let start_type = self.query_start_type(&scm, &name).unwrap_or(0);
+
+            result.push(ServiceInfo { name, display_name, state, start_type });
+        }
+
+        Ok(result)
+    }
+
+    pub fn get_status(&self, name: &str) -> Result<u32, Error> {
+        let scm = Self::open_scm(SC_MANAGER_CONNECT)?;
+        let svc = Self::open_service(&scm, name, SERVICE_QUERY_STATUS)?;
+
+        let mut status = SERVICE_STATUS_PROCESS::default();
+        let mut bytes_needed: u32 = 0;
+
+        unsafe {
+            QueryServiceStatusEx(
+                svc.0,
+                SC_STATUS_PROCESS_INFO,
+                Some(std::slice::from_raw_parts_mut(
+                    &mut status as *mut _ as *mut u8,
+                    std::mem::size_of::<SERVICE_STATUS_PROCESS>(),
+                )),
+                &mut bytes_needed,
+            )?;
+        }
+
+        Ok(status.dwCurrentState.0)
+    }
+
+    pub fn start(&self, name: &str) -> Result<(), Error> {
+        let scm = Self::open_scm(SC_MANAGER_CONNECT)?;
+        let svc = Self::open_service(&scm, name, SERVICE_START)?;
+        unsafe { StartServiceW(svc.0, None) }
+    }
+
+    pub fn stop(&self, name: &str) -> Result<(), Error> {
+        let scm = Self::open_scm(SC_MANAGER_CONNECT)?;
+        let svc = Self::open_service(&scm, name, SERVICE_STOP)?;
+        let mut status = SERVICE_STATUS::default();
+        unsafe { ControlService(svc.0, SERVICE_CONTROL_STOP, &mut status) }
+    }
+
+    pub fn create(
+        &self,
+        name: &str,
+        display_name: &str,
+        binary_path: &str,
+        start_type: u32,
+    ) -> Result<(), Error> {
+        let scm = Self::open_scm(SC_MANAGER_CREATE_SERVICE)?;
+
+        let name_w = to_wide(name);
+        let display_w = to_wide(display_name);
+        let path_w = to_wide(binary_path);
+
+        let handle = unsafe {
+            CreateServiceW(
+                scm.0,
+                PCWSTR(name_w.as_ptr()),
+                PCWSTR(display_w.as_ptr()),
+                SERVICE_ALL_ACCESS,
+                SERVICE_WIN32_OWN_PROCESS,
+                SERVICE_START_TYPE(start_type),
+                SERVICE_ERROR_NORMAL,
+                PCWSTR(path_w.as_ptr()),
+                PCWSTR::null(),
+                None,
+                PCWSTR::null(),
+                PCWSTR::null(),
+                PCWSTR::null(),
+            )
+        }?;
+
+        unsafe { CloseServiceHandle(handle).ok() };
+        Ok(())
+    }
+
+    pub fn delete(&self, name: &str) -> Result<(), Error> {
+        let scm = Self::open_scm(SC_MANAGER_CONNECT)?;
+        let svc = Self::open_service(&scm, name, DELETE)?;
+        unsafe { DeleteService(svc.0) }
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod manager;


### PR DESCRIPTION
- Add ServiceManager using Win32 SCM APIs (list, get status, start, stop, create, delete)
- Add DllOverrideManager via HKCU\Software\Wine\DllOverrides registry
- Implement real wineboot using CreateProcessW with WinebootMode enum
- Implement real GetDriveInfo using GetLogicalDrives + GetVolumeInformationW
- Wire all new gRPC handlers in lib.rs
- Fix registry/manager.rs namespace (proto::winebridge)
- Add Win32_System_Services and Win32_Storage_FileSystem crate features